### PR TITLE
Add a dependency on ecoinvent_interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 brightway25>=1.0.6
+ecoinvent_interface>=2.4.1
 pypardiso


### PR DESCRIPTION
We want to be able to use `bw2io.import_ecoinvent_release()` in a docker instance, but the required `ecoinvent_interface` package is not currently included in the base image.